### PR TITLE
Moving project to netstandard2.0

### DIFF
--- a/BuildAssets/Octopus.CoreParsers.Hcl.nuspec
+++ b/BuildAssets/Octopus.CoreParsers.Hcl.nuspec
@@ -24,7 +24,7 @@
     </dependencies>
   </metadata>
   <files>
-	<file src="netcoreapp2.0\Octopus.CoreParsers.Hcl.dll" target="lib\netcoreapp2.0" />
+	<file src="netstandard2.0\Octopus.CoreParsers.Hcl.dll" target="lib\netstandard2.0" />
 	<file src="net40\Octopus.CoreParsers.Hcl.dll" target="lib\net40" />
   </files>
 </package>

--- a/source/Octopus.Core.Parsers.Hcl/Octopus.CoreParsers.Hcl.csproj
+++ b/source/Octopus.Core.Parsers.Hcl/Octopus.CoreParsers.Hcl.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<AssemblyName>Octopus.CoreParsers.Hcl</AssemblyName>
 	<RootNamespace>Octopus.Core.Parsers.Hcl</RootNamespace>


### PR DESCRIPTION
This is part of the work to get us closer to releasing Octopus running on .net core 