### PR TITLE
Add SingleLineComment support to object

### DIFF
--- a/source/Octopus.Core.Parsers.Hcl.Tests/Octopus/CoreParsers/Hcl/Hcl2TemplateParserTest.cs
+++ b/source/Octopus.Core.Parsers.Hcl.Tests/Octopus/CoreParsers/Hcl/Hcl2TemplateParserTest.cs
@@ -46,14 +46,17 @@ namespace Octopus.CoreParsers.Hcl
             result.ToString().Should().Be(expected);
         }
 
-        [TestCase("object({name = \"string\", age = \"number\"})")]
-        [TestCase("object({name = \"string\", age = object({name = \"string\", age = \"number\"})})")]
+        [TestCase("object({name = \"string\", age = \"number\"})", -1)]
+        [TestCase("object({name = \"string\", age = object({name = \"string\", age = \"number\"})})", -1)]
+        [TestCase("object({\n  name = \"string\"\n  # this is a name\n  age = \"number\"\n  # this is the age\n})", 0)]
         [TestCase(
-            "object({name = \"string\", age = object({name = \"string\", age = \"number\"}), address = tuple([\"string\", object({name = \"string\", age = \"number\"})])})")]
-        public void ObjectTypeTest(string index)
+            "object({name = \"string\", age = object({name = \"string\", age = \"number\"}), address = tuple([\"string\", object({name = \"string\", age = \"number\"})])})",
+            -1
+        )]
+        public void ObjectTypeTest(string index, int indent)
         {
             var result = HclParser.ObjectTypeProperty.Parse(index);
-            result.ToString(-1).Should().Be(index);
+            result.ToString(indent).Should().Be(index);
         }
 
         [TestCase("tuple([\"string\", \"number\"])")]

--- a/source/Octopus.Core.Parsers.Hcl/Octopus/CoreParsers/Hcl/HclParser.cs
+++ b/source/Octopus.Core.Parsers.Hcl/Octopus/CoreParsers/Hcl/HclParser.cs
@@ -575,6 +575,7 @@ namespace Octopus.CoreParsers.Hcl
                 (
                     from value in ElementTypedObjectProperty
                         .Or(PrimitiveTypeObjectProperty)
+                        .Or(SingleLineComment)
                     from comma in Comma.Optional()
                     select value
                 ).Token().Many()


### PR DESCRIPTION
We use this library to parse modules and stumbled upon an error when trying to parse a variable declaration for an object type that contained comments on some of the properties, e.g.:

```hcl
variable "foo" {
  type = object({
    # this prop is really important for reasons
    bar = string
    # this one...who knows
    baz = string
}
```

I made a very small change to add support for SingeLineComments into the definition for ObjectTypeProperty. I'm not sure if this is the correct thing to do, but I added a test case and things are passing. Hurray!