### PR TITLE
Removed Octopus.CoreUtilities reference

### DIFF
--- a/source/Octopus.Core.Parsers.Hcl/Octopus.CoreParsers.Hcl.csproj
+++ b/source/Octopus.Core.Parsers.Hcl/Octopus.CoreParsers.Hcl.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
     <PackageReference Include="Sprache" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
We are consolidating [CoreUtilities](https://github.com/OctopusDeploy/CoreUtilities) into Octopus server. 

HCLParser is also referenced in Octopus server and the `Octopus.CoreUtilities` reference results in run-time assembly conflict. (Details [discussion](https://octopusdeploy.slack.com/archives/C03N8GGP86Q/p1667865828014199))

This work will remove the `Octopus.CoreUtilities` dependency from this library.